### PR TITLE
feat: database reader file and cron service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <gravitee-bom.version>1.1</gravitee-bom.version>
         <gravitee-common.version>1.15.5</gravitee-common.version>
         <geoip2.version>2.15.0</geoip2.version>
+        <guava.version>30.1.1-jre</guava.version>
     </properties>
 
     <dependencyManagement>
@@ -111,6 +112,14 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+        </dependency>
+
+        <!-- Guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/io/gravitee/service/geoip/cache/GeoIpCache.java
+++ b/src/main/java/io/gravitee/service/geoip/cache/GeoIpCache.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.service.geoip.cache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.vertx.core.json.JsonObject;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GeoIpCache {
+
+    private final Cache<InetAddress, JsonObject> cache;
+
+    public GeoIpCache(int capacity) {
+        cache = CacheBuilder.newBuilder()
+                .expireAfterWrite(10, TimeUnit.HOURS)
+                .maximumSize(capacity)
+                .build();
+    }
+
+    public JsonObject get(InetAddress ip) {
+        return cache.getIfPresent(ip);
+    }
+
+    public void put(InetAddress ip, JsonObject geoIp) {
+        cache.put(ip, geoIp);
+    }
+
+    public Map<InetAddress, JsonObject> getCache() {
+        return cache.asMap();
+    }
+}

--- a/src/main/java/io/gravitee/service/geoip/configuration/GeoIPServiceConfiguration.java
+++ b/src/main/java/io/gravitee/service/geoip/configuration/GeoIPServiceConfiguration.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.service.geoip.configuration;
+
+import io.gravitee.service.geoip.cache.GeoIpCache;
+import io.gravitee.service.geoip.service.DatabaseReaderWatcherService;
+import io.gravitee.service.geoip.service.DatabaseReaderService;
+import io.gravitee.service.geoip.service.DatabaseReaderServiceImpl;
+import io.gravitee.service.geoip.service.GeoIpFinderService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class GeoIPServiceConfiguration {
+
+    @Value("${geoip.database.city.filename:#{null}}")
+    private String filename;
+
+    @Value("${geoip.database.city.watch:false}")
+    private boolean watch;
+
+    @Value("${geoip.database.city.cache.capacity:4096}")
+    private int cityCacheCapacity;
+
+    @Bean
+    public GeoIpCache geoIpCache() {
+        return new GeoIpCache(cityCacheCapacity < 1 ? 4096 : cityCacheCapacity);
+    }
+
+    @Bean
+    public DatabaseReaderService databaseReaderService() {
+        return new DatabaseReaderServiceImpl();
+    }
+
+    @Bean
+    public GeoIpFinderService geoIpFinderService() {
+        return new GeoIpFinderService();
+    }
+
+    @Bean
+    public DatabaseReaderWatcherService databaseReaderCronService(
+            GeoIpCache geoIpCache,
+            GeoIpFinderService geoIpFinderService,
+            DatabaseReaderService databaseReaderService) {
+        return new DatabaseReaderWatcherService(databaseReaderService, geoIpFinderService, geoIpCache, filename).start(watch);
+    }
+}

--- a/src/main/java/io/gravitee/service/geoip/service/DatabaseReaderService.java
+++ b/src/main/java/io/gravitee/service/geoip/service/DatabaseReaderService.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.service.geoip.service;
+
+import com.maxmind.geoip2.DatabaseReader;
+
+import java.io.IOException;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface DatabaseReaderService {
+
+    String CITY_DB_TYPE = "GeoLite2-City";
+    String DATABASES_GEO_LITE_2_CITY_MMDB = "/databases/GeoLite2-City.mmdb";
+
+     void put(String key, DatabaseReader value);
+
+     DatabaseReader get(String key);
+
+     void close() throws IOException;
+}

--- a/src/main/java/io/gravitee/service/geoip/service/DatabaseReaderServiceImpl.java
+++ b/src/main/java/io/gravitee/service/geoip/service/DatabaseReaderServiceImpl.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.service.geoip.service;
+
+import com.maxmind.geoip2.DatabaseReader;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DatabaseReaderServiceImpl implements DatabaseReaderService {
+
+    private final Map<String, DatabaseReader> readers = new ConcurrentHashMap<>();
+
+    @Override
+    public DatabaseReader get(String key) {
+        return readers.get(key);
+    }
+
+    @Override
+    public void put(String key, DatabaseReader value) {
+        readers.put(key, value);
+    }
+
+    public void close() throws IOException {
+        for (DatabaseReader databaseReader : readers.values()) {
+            databaseReader.close();
+        }
+    }
+}

--- a/src/main/java/io/gravitee/service/geoip/service/DatabaseReaderWatcherService.java
+++ b/src/main/java/io/gravitee/service/geoip/service/DatabaseReaderWatcherService.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.service.geoip.service;
+
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.DatabaseReader.Builder;
+import io.gravitee.service.geoip.cache.GeoIpCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchService;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.sun.nio.file.SensitivityWatchEventModifier.HIGH;
+import static io.gravitee.service.geoip.service.DatabaseReaderService.CITY_DB_TYPE;
+import static io.gravitee.service.geoip.service.DatabaseReaderService.DATABASES_GEO_LITE_2_CITY_MMDB;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DatabaseReaderWatcherService implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DatabaseReaderWatcherService.class);
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final DatabaseReaderService databaseReaderService;
+    private final String cityNameDatabase;
+    private final GeoIpFinderService geoIpFinderService;
+    private final GeoIpCache cache;
+    private boolean started;
+
+    public DatabaseReaderWatcherService(
+            DatabaseReaderService databaseReaderService,
+            GeoIpFinderService geoIpFinderService,
+            GeoIpCache cache,
+            String cityNameDatabase
+    ) {
+        this.cache = cache;
+        this.databaseReaderService = databaseReaderService;
+        this.geoIpFinderService = geoIpFinderService;
+        this.cityNameDatabase = cityNameDatabase;
+    }
+
+    @Override
+    public void run() {
+        try {
+            WatchService watcherService = FileSystems.getDefault().newWatchService();
+            final File file = new File(cityNameDatabase);
+            Path path = file.toPath();
+            Path directory = path.getParent();
+            directory.register(watcherService, new Kind[]{ENTRY_MODIFY}, HIGH);
+            while (started) {
+                var watchKey = watcherService.poll(200, TimeUnit.MILLISECONDS);
+                if (nonNull(watchKey)) {
+                    watchKey.pollEvents().stream()
+                            .map(watchEvent -> ((WatchEvent<Path>) watchEvent).context().getFileName())
+                            .filter(path.getFileName()::equals)
+                            .findAny()
+                            .ifPresent(__ -> loadDatabase(cityNameDatabase, CITY_DB_TYPE, DATABASES_GEO_LITE_2_CITY_MMDB));
+                    if (!watchKey.reset()) {
+                        throw new InterruptedException("watchKey could not reset");
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Password dictionary watcher stopped. Reason:", e);
+        }
+    }
+
+    public DatabaseReaderWatcherService start(boolean watch) {
+        started = true;
+        if (nonNull(cityNameDatabase)) {
+            executor.submit(() -> loadDatabase(cityNameDatabase, CITY_DB_TYPE, DATABASES_GEO_LITE_2_CITY_MMDB));
+            if (watch) {
+                executor.submit(this);
+            }
+        } else {
+            executor.submit(this.loadEmbeddedDefaultReader(CITY_DB_TYPE, DATABASES_GEO_LITE_2_CITY_MMDB));
+        }
+        return this;
+    }
+
+    private void loadDatabase(String databaseName, String cityDbType, String databaseClasspathName) {
+        LOG.info("Loading {} database", cityDbType);
+        var optionalReader = loadReader(databaseName, false);
+        optionalReader.ifPresentOrElse(
+                // If present we load the new reader
+                refreshAndLoadDatabase(cityDbType),
+                // Unless there is no reader present (we might have a working reader before) we load the embedded db
+                loadEmbeddedDefaultReader(cityDbType, databaseClasspathName));
+    }
+
+    private Consumer<DatabaseReader> refreshAndLoadDatabase(String cityDbType) {
+        return reader -> {
+            databaseReaderService.put(cityDbType, reader);
+            // We refresh only if there was data before
+            var oldReader = databaseReaderService.get(cityDbType);
+            if (nonNull(oldReader)) {
+                refreshDataIfNecessary(reader);
+            }
+            LOG.info("{} database loaded", cityDbType);
+        };
+    }
+
+    private void refreshDataIfNecessary(DatabaseReader reader) {
+        final Set<InetAddress> inetAddresses = this.cache.getCache().keySet();
+        inetAddresses.forEach(ip -> {
+            try {
+                this.cache.put(ip, this.geoIpFinderService.retrieveCityGeoData(ip, reader));
+            } catch (Exception e) {
+                LOG.error("Could not refresh entry {}, reason:", ip, e);
+            }
+        });
+    }
+
+    private Runnable loadEmbeddedDefaultReader(String cityDbType, String databaseClasspathName) {
+        return () -> {
+            // We load only once the embedded data
+            // we don't want to override if the previous databaseReader worked
+            if (isNull(databaseReaderService.get(cityDbType))) {
+                var optionalDefaultReader = loadReader(databaseClasspathName, true);
+                if (optionalDefaultReader.isPresent()) {
+                    LOG.info("Fallback to {} embedded database", CITY_DB_TYPE);
+                    databaseReaderService.put(cityDbType, optionalDefaultReader.get());
+                    LOG.info("{} embedded database loaded", cityDbType);
+                }
+            }
+        };
+    }
+
+    private Optional<DatabaseReader> loadReader(String filename, boolean isClasspath) {
+        try {
+            var inputStream = isClasspath ? this.getClass().getResourceAsStream(filename) : new FileInputStream(filename);
+            return Optional.of(new Builder(inputStream).build());
+        } catch (IOException e) {
+            LOG.error("An unexpected error has occurred", e);
+        }
+        return Optional.empty();
+    }
+
+    public void close() {
+        LOG.info("Closing {} ", this.getClass().getName());
+        started = false;
+        executor.shutdown();
+        LOG.info("{} closed", this.getClass().getName());
+    }
+}

--- a/src/main/java/io/gravitee/service/geoip/service/GeoIpFinderService.java
+++ b/src/main/java/io/gravitee/service/geoip/service/GeoIpFinderService.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.service.geoip.service;
+
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.record.*;
+import io.vertx.core.json.JsonObject;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.EnumSet;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GeoIpFinderService {
+
+
+    public JsonObject retrieveCityGeoData(InetAddress ipAddress, DatabaseReader databaseReader) throws IOException, GeoIp2Exception {
+        JsonObject geo = new JsonObject();
+
+        CityResponse response = databaseReader.city(ipAddress);
+
+        Country country = response.getCountry();
+        City city = response.getCity();
+        Location location = response.getLocation();
+        Continent continent = response.getContinent();
+        Subdivision subdivision = response.getMostSpecificSubdivision();
+
+        for (Property property : Property.ALL_CITY_PROPERTIES) {
+            switch (property) {
+                case COUNTRY_ISO_CODE:
+                    geo.put("country_iso_code", country.getIsoCode());
+                    break;
+                case COUNTRY_NAME:
+                    geo.put("country_name", country.getName());
+                    break;
+                case CONTINENT_NAME:
+                    geo.put("continent_name", continent.getName());
+                    break;
+                case REGION_NAME:
+                    geo.put("region_name", subdivision.getName());
+                    break;
+                case CITY_NAME:
+                    geo.put("city_name", city.getName());
+                    break;
+                case TIMEZONE:
+                    geo.put("timezone", location.getTimeZone());
+                    break;
+                case LOCATION:
+                    geo.put("lat", location.getLatitude());
+                    geo.put("lon", location.getLongitude());
+                    break;
+            }
+        }
+        return geo;
+    }
+
+    enum Property {
+        IP,
+        COUNTRY_ISO_CODE,
+        COUNTRY_NAME,
+        CONTINENT_NAME,
+        REGION_NAME,
+        CITY_NAME,
+        TIMEZONE,
+        LOCATION;
+
+        static final EnumSet<Property> ALL_CITY_PROPERTIES = EnumSet.allOf(Property.class);
+    }
+}

--- a/src/test/java/io/gravitee/service/geoip/cache/ConcurrentLinkedHashMapCacheTest.java
+++ b/src/test/java/io/gravitee/service/geoip/cache/ConcurrentLinkedHashMapCacheTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.service.geoip.cache;
+
+import io.gravitee.service.geoip.utils.InetAddresses;
+import io.vertx.core.json.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static java.lang.String.format;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ConcurrentLinkedHashMapCacheTest {
+
+    private GeoIpCache cache;
+    private int capacity;
+
+    @Before
+    public void setUp() {
+        capacity = 5;
+        cache = new GeoIpCache(5);
+    }
+
+    @Test
+    public void mustLimitCache_with_5_capacity() {
+        int previousValue = -1;
+        for (int i = 0; i < 100; i++) {
+            final InetAddress ip = InetAddresses.forString(format("%d.%d.%d.%d", i, i, i, i));
+            this.cache.put(ip, new JsonObject());
+            cache.get(ip);
+            if (cache.getCache().size() < capacity) {
+                assertEquals(cache.getCache().size(), i + 1);
+            } else {
+                assertFalse(cache.getCache().containsKey(previousValue));
+            }
+            previousValue = i;
+        }
+    }
+}


### PR DESCRIPTION
closes: https://github.com/gravitee-io/issues/issues/6227

This PR introduces:
- Read a `GeoLite2-City.mmdb` from a path
- Watch the changes of the file
- Introduces Better caching with a 10h eviction window after write + refresh cache on new file

~[Cache2k](https://cache2k.org/) is used as backend cache since it handles expiration after write eviction and is lightweight (400kb)~ We're relying on guava cache
The cache implementation is not based on MaxMindDb cache since it is not very flexible

This is the configuration to use in the gateway

```yaml
# Configuration of geoip (requires geoip-plugin)
geoip:
  database:
    city:
      filename: /path/to/GeoLite2-City.mmdb #if null defaults to the embedded db
      watch: true  #if null defaults to false
      cache:
        capacity: 8200  #if null defaults to 4096
```